### PR TITLE
Moving documentation

### DIFF
--- a/doc.html
+++ b/doc.html
@@ -1,6 +1,6 @@
 <!DOCTYPE meta PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
    <head>
-      <meta http-equiv="refresh" content="0;url=https://github.com/genepattern/CellFie/blob/master/docs.md">
+      <meta http-equiv="refresh" content="0;url=https://github.com/LewisLabUCSD/CellFie/wiki/Documentation">
    </head>
 </html>

--- a/docs.md
+++ b/docs.md
@@ -1,5 +1,8 @@
 # **CellFie**: Cellular Functions InferencE
 
+![Cellfie_Logo](https://github.com/bkellman/CellFie/blob/master/logo_with_name.png)
+
+
 An alternative approach to capture the breadth of cellular functions by performing a functional analysis of existing biological networks.
 
 
@@ -12,8 +15,8 @@ For issues with the GenePattern module, please contact atwenzel@eng.ucsd.edu
 
 ## Input:
 **Gene expression matrix can be provide in .mat, .csv, or .xlsx**
-- For **.mat** files, you need to provide a structure variable (named e.g. data) containing a cell field named “genes” containing the NCBI Entrez gene ID (one gene by cell) and a double field named “value” containing a matrix with gene expression value for each of the sample you want to evaluate (i.e. with rows corresponding to genes and columns corresponding to samples). See available example dataTest.mat. (attach a link for downloading the following document “dataTest.mat”)
-- For **.csv or .xlsx** files, you need to provide an expression matrix with rows corresponding to genes and columns corresponding to samples. The first column is the list of genes NCBI Entrez gene ID and the first header row should start with “genes” and be followed by the name of each sample present in your dataset. See available example dataTest.csv.(attach a link for downloading the following document “dataTest.csv”)
+- For **.mat** files, you need to provide a structure variable (named e.g. data) containing a cell field named “genes” containing the NCBI Entrez gene ID (one gene by cell) and a double field named “value” containing a matrix with gene expression value for each of the sample you want to evaluate (i.e. with rows corresponding to genes and columns corresponding to samples). See available example [dataTest.mat](https://github.com/bkellman/CellFie/blob/master/test/suite/dataTest.mat)
+- For **.csv or .xlsx** files, you need to provide an expression matrix with rows corresponding to genes and columns corresponding to samples. The first column is the list of genes NCBI Entrez gene ID and the first header row should start with “genes” and be followed by the name of each sample present in your dataset. See available example [dataTest.csv](https://github.com/bkellman/CellFie/blob/master/test/suite/dataTest.csv) or [dataTest.xlsx](https://github.com/bkellman/CellFie/blob/master/test/suite/dataTest.xlsx)
 
 Note: The list of genes and associated NCBI Entrez ID present in each reference model can be [downloaded here](https://github.com/bkellman/CellFie/raw/master/docs/NCBI_Entrez_gene_ID_models.xlsx)
 

--- a/prerelease.version
+++ b/prerelease.version
@@ -1,7 +1,9 @@
+#updated after building 2.4
+#Thu, 05 Mar 2020 13:48:42 -0500
 #updated after building 1.3
 #Fri, 14 Feb 2020 16:28:24 -0500
 #updated after building 1.2
 #Fri, 18 Oct 2019 15:24:33 -0400
 #updated after building 1.1
 #Fri, 18 Oct 2019 14:57:23 -0400
-prerelease.number=4
+prerelease.number=5


### PR DESCRIPTION
This pull request updates `doc.html` to point to the [Lewis Lab github-hosted documentation](https://github.com/LewisLabUCSD/CellFie/wiki/Documentation) as they requested. This commits in this pull request prior to this change are therefore irrelevant because we are no longer hosting the latest documentation. On that note I'd like to delete `docs.md` from this repository to avoid future confusion. If that's ok, I'll make one more commit to this pull request to do that and then we can merge.