### PR TITLE
spelling mistakes + docs link

### DIFF
--- a/manifest
+++ b/manifest
@@ -1,7 +1,7 @@
 #CellFie
 #Fri Feb 14 18:30:50 UTC 2020
 JVMLevel=
-LSID=urn\:lsid\:broad.mit.edu\:cancer.software.genepattern.module.analysis\:00405\:1.5
+LSID=urn\:lsid\:broad.mit.edu\:cancer.software.genepattern.module.analysis\:00405\:1.6
 author=Benjamin Kellman;UC San Diego
 categories=metabolomics
 commandLine=sh /CellFie/matlab_compiled/execCellfie/for_redistribution_files_only/run_execCellfie.sh /usr/local/MATLAB/MATLAB_Runtime/v94 <InputData> <SampleNumber> <ReferenceModel> <ThreshType> <PercentileOrValue> <LocalThresholdType> <ThresholdLowerBound> <ThresholdUpperBound> ./
@@ -122,4 +122,4 @@ quality=production
 taskDoc=doc.html
 taskType=metabolomics
 userid=atwenzel2
-version=Incorporating bug fixes from devs to release version 1.5
+version=Incorporating bug fixes from devs to release version 1.5 + fixing small typos for version 1.6

--- a/manifest
+++ b/manifest
@@ -15,7 +15,7 @@ os=any
 p1_MODE=IN
 p1_TYPE=FILE
 p1_default_value=
-p1_description=Gene expression matrix can be provide in .mat or .csv. For .mat files, you need to provide a structure variable (named e.g. data) containing a cell field named "genes" containing the NCBI Entrez gene ID (one gene by cell) and a double field named "value" containing a matrix with gene expression value for each of the sample you want to evaluate (i.e. with rows corresponding to genes and columns corresponding to samples). See available example dataTest.mat. (attach a link for downloading the following document "dataTest.mat") For csv. files, you need to provide an expression matrix with rows corresponding to genes and columns corresponding to samples. The first column is the list of genes NCBI Entrez gene ID and the first header row should start with "genes" and be followed by the name of each sample present in your dataset. See available example dataTest.csv.(https\://github.com/LewisLabUCSD/CellFie/blob/master/test/suite/dataTest.csv)\nThe list of genes and associated NCBI Entrez ID present in each reference model can be\ndownloaded here (https\://github.com/LewisLabUCSD/CellFie/raw/master/docs/NCBI_Entrez_gene_ID_models.xlsx).
+p1_description=Gene expression matrix can be provide in .mat or .csv. For .mat files, you need to provide a structure variable (named e.g. data) containing a cell field named "genes" containing the NCBI Entrez gene ID (one gene by cell) and a double field named "value" containing a matrix with gene expression value for each of the sample you want to evaluate (i.e. with rows corresponding to genes and columns corresponding to samples). See available example dataTest.mat. (https\://github.com/LewisLabUCSD/CellFie/blob/master/test/suite/dataTest.mat) For csv. files, you need to provide an expression matrix with rows corresponding to genes and columns corresponding to samples. The first column is the list of genes NCBI Entrez gene ID and the first header row should start with "genes" and be followed by the name of each sample present in your dataset. See available example dataTest.csv.(https\://github.com/LewisLabUCSD/CellFie/blob/master/test/suite/dataTest.csv)\nThe list of genes and associated NCBI Entrez ID present in each reference model can be\ndownloaded here (https\://github.com/LewisLabUCSD/CellFie/raw/master/docs/NCBI_Entrez_gene_ID_models.xlsx).
 p1_fileFormat=csv
 p1_flag=
 p1_name=InputData
@@ -50,7 +50,7 @@ p3_optional=
 p3_prefix=
 p3_prefix_when_specified=
 p3_type=java.lang.String
-p3_value=MT_recon_2_2_entrez.mat\=Human_recon_2_2;MT_iCHOv1_final.mat\=CHO_iCHOv1;MT_iHsa.mat\=Human_iHsa;MT_iMM1415.mat\=Mosue_iMM1415;MT_iRno.mat\=Rat_iRn
+p3_value=MT_recon_2_2_entrez.mat\=Human_recon_2_2;MT_iCHOv1_final.mat\=CHO_iCHOv1;MT_iHsa.mat\=Human_iHsa;MT_iMM1415.mat\=Mouse_iMM1415;MT_iRno.mat\=Rat_iRn
 p4_MODE=
 p4_TYPE=TEXT
 p4_default_value=local

--- a/prerelease.version
+++ b/prerelease.version
@@ -8,4 +8,4 @@
 #Fri, 18 Oct 2019 15:24:33 -0400
 #updated after building 1.1
 #Fri, 18 Oct 2019 14:57:23 -0400
-prerelease.number=6
+prerelease.number=7

--- a/prerelease.version
+++ b/prerelease.version
@@ -1,3 +1,5 @@
+#updated after building 1.6
+#Thu, 02 Apr 2020 18:05:36 -0400
 #updated after building 1.5
 #Fri, 27 Mar 2020 16:52:48 -0400
 #updated after building 2.4
@@ -8,4 +10,4 @@
 #Fri, 18 Oct 2019 15:24:33 -0400
 #updated after building 1.1
 #Fri, 18 Oct 2019 14:57:23 -0400
-prerelease.number=6
+prerelease.number=7

--- a/prerelease.version
+++ b/prerelease.version
@@ -8,4 +8,4 @@
 #Fri, 18 Oct 2019 15:24:33 -0400
 #updated after building 1.1
 #Fri, 18 Oct 2019 14:57:23 -0400
-prerelease.number=7
+prerelease.number=6


### PR DESCRIPTION
Added a link to a test file and fixed a parameter spelling mistake. The module should go to the next minor version, I'm not sure if that's 1.6 or 1.7? Anyway, the `prerelease.version` was bumped from 6 to 7.