### PR TITLE
add paramgroups to zip build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
 <target name="create-zip" depends="init">
     <antcall target="prezip"/>
     <zip destfile="${dest.dir}/${ant.project.name}.zip" whenempty="fail" defaultexcludes="true">
-        <fileset dir="." includes="manifest, doc.html"/>
+        <fileset dir="." includes="manifest, doc.html, paramgroups.json"/>
     </zip>
     <antcall target="postzip"/>
 </target>


### PR DESCRIPTION
Add the `paramgroups.json` file to the module zip in `build.xml` to enable an "advanced parameters" folding section.

Jenkins will need to be run after this PR is approved.